### PR TITLE
Use local OSTree repo in Builder if available

### DIFF
--- a/debian/features/ostreeImage/.gitignore
+++ b/debian/features/ostreeImage/.gitignore
@@ -1,0 +1,1 @@
+ostree-debian-repo*.tar.gz

--- a/debian/features/ostreeImage/image.ostree.raw
+++ b/debian/features/ostreeImage/image.ostree.raw
@@ -19,21 +19,30 @@ OSTREE_REF="debian/testing/$BUILDER_ARCH"
 REMOTE_URL="http://ostree.gardenlinux.io"
 REMOTE_ARCHIVE_NAME=ostree-debian-repo-${BUILDER_ARCH}.tar.gz
 
+LOCAL_ARCHIVE_PATH=/builder/features/ostreeImage/$REMOTE_ARCHIVE_NAME
+
 rootfs="$1"
 output="$2"
 
 tar xf "$rootfs" -C "$rootfs_work"
 
-
 mkdir -p $OSTREE_REPO
 mkdir -p $OSTREE_SYSROOT
-download="$(mktemp -d)"
-pushd $download
-curl -fsSL --remote-name $REMOTE_URL/$REMOTE_ARCHIVE_NAME
-tar xf $REMOTE_ARCHIVE_NAME --directory $OSTREE_REPO
-ls -l $OSTREE_REPO
-popd
-rm -rf $download
+
+if [ -f $LOCAL_ARCHIVE_PATH ]; then
+    echo Found local OSTree repo file at $LOCAL_ARCHIVE_PATH, using it to build the image
+    tar xf $LOCAL_ARCHIVE_PATH --directory $OSTREE_REPO
+else
+    echo Did not find a local OSTree repo file, downloading from remote repo
+    download="$(mktemp -d)"
+    pushd $download
+    curl -fsSL --remote-name $REMOTE_URL/$REMOTE_ARCHIVE_NAME
+    tar xf $REMOTE_ARCHIVE_NAME --directory $OSTREE_REPO
+    ls -l $OSTREE_REPO
+    popd
+    rm -rf $download
+fi
+
 ostree admin deploy --karg=root=LABEL=ROOT --karg-append=rw --karg-append=efi=runtime --sysroot=$OSTREE_SYSROOT --os=debian $OSTREE_REF
 
 boot_hash=`ls "$OSTREE_SYSROOT"/ostree/boot.1.1/debian/`

--- a/debian/features/ostreeRepo/.gitignore
+++ b/debian/features/ostreeRepo/.gitignore
@@ -1,0 +1,1 @@
+ostree-debian-repo*.tar.gz

--- a/debian/features/ostreeRepo/image.ostreeRepo.tar.gz
+++ b/debian/features/ostreeRepo/image.ostreeRepo.tar.gz
@@ -18,6 +18,8 @@ REMOTE_URL="http://ostree.gardenlinux.io"
 REMOTE_ARCHIVE_NAME=ostree-debian-repo-${BUILDER_ARCH}.tar.gz
 REMOTE_NAME=debian-repo-${BUILDER_ARCH}
 
+LOCAL_ARCHIVE_PATH=/builder/features/ostreeRepo/$REMOTE_ARCHIVE_NAME
+
 rootfs="$1"
 output="$2"
 
@@ -27,23 +29,25 @@ mv "$rootfs_work"/etc "$rootfs_work"/usr/etc
 
 mkdir -p $OSTREE_REPO
 
-if curl --head --silent --fail $REMOTE_URL/$REMOTE_ARCHIVE_NAME 2> /dev/null;
- then
-    echo "Using $REMOTE_URL/$REMOTE_ARCHIVE_NAME"
-    mkdir -p $OSTREE_REPO
-    download="$(mktemp -d)"
-    pushd $download
-    curl -fsSL --remote-name $REMOTE_URL/$REMOTE_ARCHIVE_NAME
-    tar xf $REMOTE_ARCHIVE_NAME --directory $OSTREE_REPO
-    popd
-    rm -rf $download
- else
-    echo "Coud not download $REMOTE_URL/$REMOTE_ARCHIVE_NAME, building new repo"
+download="$(mktemp -d)"
+pushd $download
+
+if [ -f $LOCAL_ARCHIVE_PATH ]; then
+   echo "Using local file from $LOCAL_ARCHIVE_PATH"
+   tar xf $LOCAL_ARCHIVE_PATH --directory $OSTREE_REPO
+elif [ $(curl -sSL --remote-name -w "%{http_code}" $REMOTE_URL/$REMOTE_ARCHIVE_NAME) -eq 200 ]; then
+   echo "Using remote file from $REMOTE_URL/$REMOTE_ARCHIVE_NAME"
+   tar xf $REMOTE_ARCHIVE_NAME --directory $OSTREE_REPO
+else
+    echo "Coud use local file from $LOCAL_ARCHIVE_PATH or remote file from $REMOTE_URL/$REMOTE_ARCHIVE_NAME, building new repo"
     ostree init --mode=archive --repo=$OSTREE_REPO
     ostree admin init-fs --modern $OSTREE_SYSROOT
     ostree admin os-init --sysroot=$OSTREE_SYSROOT debian
     ostree config --repo=$OSTREE_REPO set sysroot.bootloader none
 fi
+
+popd
+rm -rf $download
 
 ostree remote --repo=$OSTREE_REPO delete --if-exists origin
 ostree remote --repo=$OSTREE_REPO add --no-gpg-verify --no-sign-verify origin $REMOTE_URL/$REMOTE_NAME $OSTREE_REF

--- a/gardenlinux/features/ostreeImage/.gitignore
+++ b/gardenlinux/features/ostreeImage/.gitignore
@@ -1,1 +1,2 @@
 BUILD_VARIANT
+ostree-gardenlinux-repo*.tar.gz

--- a/gardenlinux/features/ostreeImage/image.ostree.raw
+++ b/gardenlinux/features/ostreeImage/image.ostree.raw
@@ -23,6 +23,7 @@ BUILD_VARIANT="${BUILD_VARIANT:-kvm}"
 REMOTE_URL="http://ostree.gardenlinux.io"
 REMOTE_ARCHIVE_NAME=ostree-gardenlinux-repo-${BUILD_VARIANT}-${BUILDER_ARCH}.tar.gz
 REMOTE_NAME=gardenlinux-repo-${BUILD_VARIANT}-${BUILDER_ARCH}
+LOCAL_ARCHIVE_PATH=/builder/features/ostreeImage/$REMOTE_ARCHIVE_NAME
 
 rootfs="$1"
 output="$2"
@@ -33,13 +34,21 @@ tar xf "$rootfs" -C "$rootfs_work"
 
 mkdir -p $OSTREE_REPO
 mkdir -p $OSTREE_SYSROOT
-download="$(mktemp -d)"
-pushd $download
-curl -fsSL --remote-name $REMOTE_URL/$REMOTE_ARCHIVE_NAME
-tar xf $REMOTE_ARCHIVE_NAME --directory $OSTREE_REPO
-ls -l $OSTREE_REPO
-popd
-rm -rf $download
+
+if [ -f $LOCAL_ARCHIVE_PATH ]; then
+    echo Found local OSTree repo file at $LOCAL_ARCHIVE_PATH, using it to build the image
+    tar xf $LOCAL_ARCHIVE_PATH --directory $OSTREE_REPO
+else
+    echo Did not find a local OSTree repo file, downloading from remote repo
+    download="$(mktemp -d)"
+    pushd $download
+    curl -fsSL --remote-name $REMOTE_URL/$REMOTE_ARCHIVE_NAME
+    tar xf $REMOTE_ARCHIVE_NAME --directory $OSTREE_REPO
+    ls -l $OSTREE_REPO
+    popd
+    rm -rf $download
+fi
+
 ostree admin deploy --karg=root=LABEL=ROOT --karg-append=rw --karg-append=efi=runtime --sysroot=$OSTREE_SYSROOT --os=gardenlinux $OSTREE_REF
 
 boot_hash=`ls "$OSTREE_SYSROOT"/ostree/boot.1.1/gardenlinux/`

--- a/gardenlinux/features/ostreeRepo/.gitignore
+++ b/gardenlinux/features/ostreeRepo/.gitignore
@@ -1,1 +1,2 @@
 BUILD_VARIANT
+ostree-gardenlinux-repo*.tar.gz

--- a/gardenlinux/features/ostreeRepo/image.ostreeRepo.tar.gz
+++ b/gardenlinux/features/ostreeRepo/image.ostreeRepo.tar.gz
@@ -22,6 +22,8 @@ REMOTE_URL="http://ostree.gardenlinux.io"
 REMOTE_ARCHIVE_NAME=ostree-gardenlinux-repo-${BUILD_VARIANT}-${BUILDER_ARCH}.tar.gz
 REMOTE_NAME=gardenlinux-repo-${BUILD_VARIANT}-${BUILDER_ARCH}
 
+LOCAL_ARCHIVE_PATH=/builder/features/ostreeRepo/$REMOTE_ARCHIVE_NAME
+
 rootfs="$1"
 output="$2"
 
@@ -33,23 +35,25 @@ mv "$rootfs_work"/etc "$rootfs_work"/usr/etc
 
 mkdir -p $OSTREE_REPO
 
-if curl --head --silent --fail $REMOTE_URL/$REMOTE_ARCHIVE_NAME 2> /dev/null;
- then
-    echo "Using $REMOTE_URL/$REMOTE_ARCHIVE_NAME"
-    mkdir -p $OSTREE_REPO
-    download="$(mktemp -d)"
-    pushd $download
-    curl -fsSL --remote-name $REMOTE_URL/$REMOTE_ARCHIVE_NAME
-    tar xf $REMOTE_ARCHIVE_NAME --directory $OSTREE_REPO
-    popd
-    rm -rf $download
- else
-    echo "Coud not download $REMOTE_URL/$REMOTE_ARCHIVE_NAME, building new repo"
+download="$(mktemp -d)"
+pushd $download
+
+if [ -f $LOCAL_ARCHIVE_PATH ]; then
+   echo "Using local file from $LOCAL_ARCHIVE_PATH"
+   tar xf $LOCAL_ARCHIVE_PATH --directory $OSTREE_REPO
+elif [ $(curl -sSL --remote-name -w "%{http_code}" $REMOTE_URL/$REMOTE_ARCHIVE_NAME) -eq 200 ]; then
+   echo "Using remote file from $REMOTE_URL/$REMOTE_ARCHIVE_NAME"
+   tar xf $REMOTE_ARCHIVE_NAME --directory $OSTREE_REPO
+else
+    echo "Coud use local file from $LOCAL_ARCHIVE_PATH or remote file from $REMOTE_URL/$REMOTE_ARCHIVE_NAME, building new repo"
     ostree init --mode=archive --repo=$OSTREE_REPO
     ostree admin init-fs --modern $OSTREE_SYSROOT
     ostree admin os-init --sysroot=$OSTREE_SYSROOT gardenlinux
     ostree config --repo=$OSTREE_REPO set sysroot.bootloader none
 fi
+
+popd
+rm -rf $download
 
 ostree remote --repo=$OSTREE_REPO delete --if-exists origin
 ostree remote --repo=$OSTREE_REPO add --no-gpg-verify --no-sign-verify origin $REMOTE_URL/$REMOTE_NAME $OSTREE_REF

--- a/gardenlinux/ostree-build.sh
+++ b/gardenlinux/ostree-build.sh
@@ -11,5 +11,5 @@ PLATFORM=$1
 
 echo $PLATFORM > features/ostreeRepo/BUILD_VARIANT
 echo $PLATFORM > features/ostreeImage/BUILD_VARIANT
-./build "$PLATFORM"_dev_curl-ostreeRepo
+# ./build "$PLATFORM"_dev_curl-ostreeRepo
 ./build ostreeImage


### PR DESCRIPTION
Before this change, the builder would always download the OSTree repo from the remote resource if available. Now it checks for a local copy of the repo first which can speed up local building.

Note that this works independently both for the `ostreeRepo` and the `ostreeImage` feature.